### PR TITLE
Check if the Google Maps API is loaded

### DIFF
--- a/js/jquery.gomap-1.3.2.js
+++ b/js/jquery.gomap-1.3.2.js
@@ -8,6 +8,11 @@
  */
 
 (function($) {
+	
+	if (!((typeof google !== "undefined" && google !== null ? google.maps : void 0) != null)) {
+	  return;
+	}
+	
 	var geocoder = new google.maps.Geocoder();
 
 	function MyOverlay(map) { this.setMap(map); };


### PR DESCRIPTION
Thanks for the plugin! I added a check at the top to see if the Google Maps API is loaded. This prevents 'Google is not defined' errors.
