### PR TITLE
Added "double" value to the "addMarker" method, for doubleclicks

### DIFF
--- a/js/jquery.gomap-1.3.2.js
+++ b/js/jquery.gomap-1.3.2.js
@@ -208,6 +208,24 @@
 						});
 					}
 				});
+			}else if (opts.addMarker == 'double') {
+				google.maps.event.addListener(goMap.map, 'dblclick', function(event) {
+					if(!goMap.singleMarker) {
+						var options = {
+							position:  event.latLng,
+							draggable: true
+						};
+
+						var marker = goMap.createMarker(options);
+						goMap.singleMarker = true;
+
+						google.maps.event.addListener(marker, 'dblclick', function(event) {
+							marker.setMap(null);
+							goMap.removeMarker(marker.id);
+							goMap.singleMarker = false;
+						});
+					}
+				});
 			}
 			delete opts.markers;
 			delete opts.overlays;


### PR DESCRIPTION
I had the need to add the marker on double click instead of single
click, so i duplicated the single click method and added a "dblclick"
event. That way it can be called like "addMarker: double" to add it
with doubleclick
